### PR TITLE
Add command CleanNote + some fix

### DIFF
--- a/doc/tags
+++ b/doc/tags
@@ -5,6 +5,7 @@
 :ZimImgCapture	zim.txt	/*:ZimImgCapture*
 :ZimImgInsert	zim.txt	/*:ZimImgInsert*
 :ZimInjectHtml	zim.txt	/*:ZimInjectHtml*
+:ZimCleanNote	zim.txt	/*:ZimCleanNote*
 :ZimList	zim.txt	/*:ZimList*
 :ZimListThis	zim.txt	/*:ZimListThis*
 :ZimMatchNext...	zim.txt	/*:ZimMatchNext...*

--- a/doc/zim.txt
+++ b/doc/zim.txt
@@ -331,6 +331,12 @@ COMMANDS                                                        *zim-commands*
                     to ZimWiki format and add the result at the current
                     position.  
 
+:ZimCleanNote                                       *:ZimCleanNote*
+                   Clean all things are supported in Vim-Zim,
+                   but not in the current version of Zim.
+                   This includes for now:
+                   - markdown codeblock
+
 ==============================================================================
 EDITOR ACTIONS AND KEYBINDINGS                                   *zim-editing*
                                                                  |zim-toc|

--- a/plugin/zim/explorer.vim
+++ b/plugin/zim/explorer.vim
@@ -54,6 +54,7 @@ function! zim#explorer#interactiveMove()
     endif
   endif
   call zim#explorer#ListUpdate()
+  redraw!
 endfunction
 
 function! zim#explorer#interactiveRename()

--- a/plugin/zim/note.vim
+++ b/plugin/zim/note.vim
@@ -188,7 +188,7 @@ function! s:setBufferSpecific()
   
   " add commamds avaible for the note
   command! -buffer -nargs=* ZimGrepThis :call zim#explorer#SearchInNotebook(expand('<cword>'))
-  command! -buffer -nargs=* ZimListThis :call zim#explorer#ListNotes(g:zim_notebook,expand('<cword>'))
+  command! -buffer -nargs=* ZimListThis :call zim#explorer#List(g:zim_notebook,expand('<cword>'))
 
   command! -buffer -nargs=1 -complete=file ZimImgInsert :call zim#editor#InsertImage(<q-args>,'')
   command! -buffer -nargs=1 -complete=file ZimImgCapture :call zim#editor#InsertImage(<q-args>,g:zim_img_capture)

--- a/plugin/zim/util.vim
+++ b/plugin/zim/util.vim
@@ -172,6 +172,7 @@ function! zim#util#line(goto_instrs, ...)
           endif
         endfor
       endif
+      if has_key(l:j, 'checkpoint') | let l:default=l:i | endif
       if has_key(l:j, 'get') | let l:mem[l:j['get']]=l:i | endif
       if has_key(l:j, 'set') | let l:i=l:mem[l:j['set']] | endif
       if has_key(l:j, 'init') | let l:i=line(l:j['init']) | endif

--- a/syntax/getsourcesfiletype.py
+++ b/syntax/getsourcesfiletype.py
@@ -16,22 +16,29 @@ if gtksourceview2:
 else:
     LANGUAGES = {}
 
+def langsubst(lzim):
+    langsubsts=[
+        (0, ' ', '-'),
+        (1,'gettext-translation', 'po'),
+        (1,'dos-batch', 'dosbatch'),
+        (1,'.ini', 'dosini'),
+        (1,"c/c++/objc-header", "cpp"),
+        (0, '#', 's'),
+        (0, '++', 'pp'),
+        (0, 'objective-', 'o'),
+        (0,'literate-', ''),
+        (0,'.','')
+    ]
+    lvim = lzim.lower()
+    for b, z, v in langsubsts:
+        if z in lvim:
+            lvim = lvim.replace(z, v)
+            if b:
+                break
+    return lzim, lvim
 
-langdict={
-"objective-caml" : 'ocaml',
-'objective-c':'objc',
-'gettext-translation':'po',
-'dos-batch':'dosbatch',
-'.ini':'dosini',
-'c#':'cs',
-'c++':'cpp',
-"c/c++/objc-header":"cpp"
-}
-ret = "let s:languages = {"
-for i in LANGUAGES:
-    lzim = i.lower().replace(' ','-')
-    lvim = langdict.get(lzim, lzim).replace('#', 's').replace('literate-','').replace('.','')
+ret = []
+for (lzim, lvim) in [langsubst(l) for l in LANGUAGES]:
     if glob('/usr/share/vim/*/syntax/'+lvim+'.vim') :
-        ret += '"' + lzim + '" : "' + lvim +  '",'
-ret += "}"
-print ret
+        ret.append('"' + lzim + '" : "' + lvim +  '"')
+print "let g:zim_codeblock_syntax = { %s }" % "\n \\ ".join(ret)

--- a/syntax/zim.vim
+++ b/syntax/zim.vim
@@ -56,11 +56,10 @@ try
 catch 
   syn match Title /^\(=\{1,6}\)[^=].*\1$/
 endtry
-"😚😰😱
+"🆚 ⍈ 🆙 🆓 🆗 🆔 🆕 😞😚😰😱
 if has('gui')
   let g:zim_emochars={'Checkbox': '😰', 'CheckboxYes': '😊', 'CheckboxNo': '😞', 'CheckboxMoved': '😴'}
 endif
-"🆚 ⍈ 🆙 🆓 🆗 🆔 🆕 😞
 if exists('g:zim_emochars')
 for s:i in keys(g:zim_emochars)
   exe 'syn match zimConcealElt'.s:i.' /\(\t\|    \)\(\[\)\@=/ conceal transparent contained cchar='.g:zim_emochars[s:i]
@@ -136,10 +135,13 @@ fu! s:activate_codeblock()
   " break spell
   let l:languages = get(g:,'zim_codeblock_syntax',
         \{"python": "python","sh": "sh","sourcecode": "sh",  "vim": "vim",
-        \ "html": "html", "css": "css",
+        \ "html": "html", "css": "css", "xml": "xml",
         \ "javascript": "javascript", "sql": "sql"}
         \)
 
+  exe 'syn include @zimcodeblockundef syntax/'.get(g:,'zim_codeblock_default_syntax', 'abc').'.vim contained'
+  syn region zimCodeBlockUndef start="\s*$"ms=e+1
+          \ end="^\s*}}}\ze\s*$"me=e-3 contained contains=@zimcodeblockundef
   " syn region markdownCode matchgroup=Delimiter start="^\s*```.*$" end="^\s*```\ze\s*$" keepend
   for l:i in keys(l:languages)
     let l:l = l:languages[l:i]
@@ -147,18 +149,15 @@ fu! s:activate_codeblock()
     unlet b:current_syntax
     exe 'syn include @zimcodeblock'.l:l.' syntax/'.l:l.'.vim contained'
     exe 'syn region zimCodeBlock'.l:l.' start=|lang="'.l:i.'".*$|ms=e+1'.
-          \' end=|^\s*}}}\ze\s*$|me=e-3 contained contains=ZimCodeBlockEnd,@zimcodeblock'.l:l
+          \' end=|^\s*}}}\ze\s*$|me=e-3 contained contains=@zimcodeblock'.l:l
 
     " markdown code support
     exe 'syn region markdownHighlight'.l:l.'  matchgroup=Delimiter start="^\s*```\s*'.l:l.'\>.*$" end="^\s*```\ze\s*$" keepend contains=@zimcodeblock'.l:l
 
   endfor
-  syn region zimCodeBlock start="^\s*{{{code: " end="^\s*}}}\ze\s*$" matchgroup=Delimiter
-        \ transparent keepend contains=@NoSpell,ZimCodeBlock.*
-  syn match ZimCodeBlockBegin /^\s*{{{code: \s*/ contained
-  syn match ZimCodeBlockEnd /^\s*}}}\s*$/ contained
-  hi def link ZimCodeBlockBegin Comment
-  hi def link ZimCodeBlockEnd Comment
+  syn region zimCodeBlock start="^\s*{{{code" end="^\s*}}}\ze\s*$" matchgroup=Delimiter
+        \ keepend contains=@NoSpell,ZimCodeBlock.*
+  hi def link ZimCodeBlock Comment
 endfu
 call s:activate_codeblock()
 


### PR DESCRIPTION
Hi
This PR include a new command that take markdown codeblock ` ``` ``` ` and convert then to zim codeblocks (markdown codeblock are easier to write)
+ a bunch of little fix
